### PR TITLE
Migrations

### DIFF
--- a/db.go
+++ b/db.go
@@ -173,3 +173,12 @@ func (s *SparkleDatabase) SparklesForUser(user string) []Sparkle {
 
 	return list
 }
+
+// MigrateSparkles moves all sparkles from <from> to <to>
+func (s *SparkleDatabase) MigrateSparkles(from, to string) {
+	for k, v := range s.Sparkles {
+		if strings.ToLower(v.Sparklee) == strings.ToLower(from) {
+			s.Sparkles[k].Sparklee = to
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func main() {
 	r.HandleFunc("/top/giver", topGiven).Methods("GET")
 	r.HandleFunc("/top/receiver", topReceived).Methods("GET")
 	r.HandleFunc("/sparkles/{recipient}", getSparklesForRecipient).Methods("GET")
+	r.HandleFunc("/migrate/{from}/{to}", migrateSparkles)
 	r.HandleFunc("/graph", getSparkleGraph).Methods("GET")
 	r.PathPrefix("/").Handler(http.FileServer(http.Dir("./public/")))
 	// Load the database from file

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	r.HandleFunc("/top/giver", topGiven).Methods("GET")
 	r.HandleFunc("/top/receiver", topReceived).Methods("GET")
 	r.HandleFunc("/sparkles/{recipient}", getSparklesForRecipient).Methods("GET")
-	r.HandleFunc("/migrate/{from}/{to}", migrateSparkles)
+	// r.HandleFunc("/migrate/{from}/{to}", migrateSparkles)
 	r.HandleFunc("/graph", getSparkleGraph).Methods("GET")
 	r.PathPrefix("/").Handler(http.FileServer(http.Dir("./public/")))
 	// Load the database from file

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// Log what's up
 func Log(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		remoteAddr := r.RemoteAddr

--- a/sparkles.go
+++ b/sparkles.go
@@ -98,3 +98,13 @@ func getSparkleGraph(w http.ResponseWriter, h *http.Request) {
 	result := db.Graph()
 	returnJSON(result, w, h)
 }
+
+// Migrate sparkles from one user to another
+func migrateSparkles(w http.ResponseWriter, h *http.Request) {
+	vars := mux.Vars(h)
+	from := vars["from"]
+	to := vars["to"]
+	db.MigrateSparkles(from, to)
+	updatedSparkles := db.SparklesForUser(to)
+	returnJSON(updatedSparkles, w, h)
+}


### PR DESCRIPTION
Make it possible to migrate :sparkle: points between usernames. Especially useful if there's been a typo or a user name change.
